### PR TITLE
0.0.5 (textstream, maxIter in training, fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 coverage/
 node_modules/
 temp/
+data/
+dist/
+mlruns/
 test.json
 .swp
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog for gpt-tfjs
+
+## 0.0.5 - 2023-07-22
+
+### Added
+
+- `textstream` project: Train GPT model using text stream in browser in node (without loading the whole dataset into memory)
+- Support both `maxIter` and `epochs` in the `train` method. Switched from `df.forEachAsync` to `while` loop + `ds.iterator()` (it was not clear how to terminate long-running `forEachAsync`).
+
+### Fixed
+
+- Memory leakage in the `generate` method
+- Use `config.lr` in the Adam optimizer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpt-tfjs",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "GPT model implemented with Tensorflow.js",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,10 @@
     "nodemon": "^2.0.22",
     "webpack": "^5.79.0",
     "webpack-cli": "^5.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zemlyansky/gpt-tfjs.git"
   },
   "keywords": [
     "gpt",

--- a/projects/textstream/README.md
+++ b/projects/textstream/README.md
@@ -1,0 +1,19 @@
+# Train a GPT model in the browser using text streaming
+
+## Using WebGPU
+
+Tested on Chrome 115.0.5790.40 beta (64-bit) on 2023/07/27
+
+- `google-chrome-beta --enable-unsafe-webgpu --enable-features=Vulkan http://localhost:8080`
+- These flags will not be needed in the future. Check the WebGPU support (for example [here](https://mdn.github.io/dom-examples/webgpu-render-demo/))
+
+## Tracking experiments with MLflow
+
+By default a browser will not be able to send metrics to a MLflow server running on a separate port (because of [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)). One way to overcome this is to create a CORS-proxy (using [local-cors-proxy](https://github.com/garmeeh/local-cors-proxy) or similar tools). Another option is disabling web security:
+
+- `mlflow server`
+- `google-chrome-beta --disable-web-security --user-data-dir="./temp" http://localhost:8080`
+
+## WebGPU + MLflow
+
+- `google-chrome-beta --disable-web-security --user-data-dir="./temp" --enable-unsafe-webgpu --enable-features=Vulkan http://localhost:8080`

--- a/projects/textstream/index.html
+++ b/projects/textstream/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Textstream</title>
+</head>
+<body>
+    <!-- File input that calls handle() on change -->
+    <input type="file" id="input">
+    <div>
+        <canvas id="plot"></canvas>
+    </div>
+    <p id="info"></p>
+    <p id="output"></p>
+    <!-- Plotting -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    
+    <!-- Tensorflow -->
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@latest"></script>
+    <script> console.log('TF backend (initial):', tf.getBackend()) </script>
+
+    <!-- CPU -->
+    <!-- <script> tf.setBackend('cpu').then(() => { console.log('TF backend (updated):', tf.getBackend()) }) </script> -->
+
+    <!-- WebGL -->
+    <!-- <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl"></script>  -->
+    <!-- <script> tf.setBackend('webgl').then(() => { console.log('TF backend (updated):', tf.getBackend()) }) </script> -->
+
+    <!-- WebGPU -->
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgpu/dist/tf-backend-webgpu.js"></script>
+    <script> tf.setBackend('webgpu').then(() => { console.log('TF backend (updated):', tf.getBackend()) }) </script>
+    
+    <!-- WebAssembly -->
+    <!-- <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@latest/dist/tf-backend-wasm.js"></script> -->
+    <!-- <script> tf.setBackend('wasm').then(() => { console.log('TF backend (updated):', tf.getBackend()) }) </script> -->
+
+    <script src="dist/bundle.js"></script>
+</body>
+</html>

--- a/projects/textstream/package.json
+++ b/projects/textstream/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "textstream",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/train-node.js",
+  "scripts": {
+    "build": "webpack --mode=development --progress --stats-children",
+    "watch": "nodemon --watch src --watch ../../src --exec \"npm run build\"",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Anton Zemlyansky",
+  "license": "MIT",
+  "dependencies": {
+    "buffer": "^6.0.3",
+    "filestream": "^5.0.0",
+    "gpt-tokenizer": "^2.1.1",
+    "path-browserify": "^1.0.1",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/projects/textstream/src/create-dataset.js
+++ b/projects/textstream/src/create-dataset.js
@@ -1,0 +1,69 @@
+const tf = require('@tensorflow/tfjs')
+
+const ReadStream = require('filestream').read
+const { encode, decode } = require('gpt-tokenizer/encoding/r50k_base')
+const vocabSize = 50257
+
+async function sleep (t) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, t);
+  });
+}
+
+function createDatasetFromTextStreams(getStreams, blockSize) {
+    let runs = 0
+    let steps = 0
+
+    async function* dataGenerator() {
+        // This is restarted on each epoch
+        // Because streams can only be read once, we need to reinit them here
+        // That's why we use a function to get the streams, rather than the streams themselves
+        // In nodejs it will return streams from fs,
+        // In the browser it will return streams from a file input
+        const streams = getStreams()
+        if (!Array.isArray(streams)) {
+            streams = [streams]
+        }
+        console.log('Starting data generator:', runs++)
+        for await (const stream of streams) {
+            for await (const chunk of stream) {
+                const text = chunk.toString()
+                const tokens = encode(text)
+                console.log(`Stream chunk: ${text.slice(0, 40)}... (${tokens.length} tokens)`)
+                for (let i = 0; i < tokens.length - blockSize - 1; i += blockSize) {
+                    const x = tokens.slice(i, i + blockSize)
+                    const y = tokens.slice(i + 1, i + blockSize + 1)
+                    yield {
+                        x,
+                        y
+                    }
+                    steps++
+                    await sleep(1)
+                }
+                await sleep(1)
+            }
+        }
+    }
+
+    return tf.data.generator(dataGenerator)
+        .map(v => ({
+            x: tf.cast(v.x, 'int32'), 
+            y: tf.oneHot(tf.cast(v.y, 'int32'), vocabSize)
+        }))
+}
+
+function createDatasetFromFileList (fileList, blockSize, chunkSize=256) {
+    const files = Array.from(fileList)
+    function getStreams () {
+        return files.map(file => new ReadStream(file, { chunkSize: chunkSize }))
+    }
+    return createDatasetFromTextStreams(getStreams, blockSize)
+}
+
+module.exports = {
+    createDatasetFromTextStreams,
+    createDatasetFromFileList,
+    vocabSize
+}

--- a/projects/textstream/src/mlflow.js
+++ b/projects/textstream/src/mlflow.js
@@ -1,0 +1,68 @@
+const headers = {
+    "Content-Type": "application/json",
+}
+
+class MLflow {
+    constructor({endpoint}) {
+        this.endpoint = endpoint ? endpoint : 'http://localhost:5000'
+        this.activeRunId = null
+    }
+
+    async createRun(experimentId, name) {
+        const body = {
+            experiment_id: experimentId,
+            run_name: name,
+            start_time: Date.now(),
+        }
+        const response = await fetch(`${this.endpoint}/api/2.0/mlflow/runs/create`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body)
+        })
+        const json = await response.json()
+        this.activeRunId = json.run.info.run_id
+        return json
+    }
+
+    async logMetric(key, value, step) {
+        if (!this.activeRunId) {
+            throw new Error('No active run')
+        }
+        const body = {
+            run_id: this.activeRunId,
+            key: key,
+            value: value,
+            timestamp: Date.now(),
+            step: step
+        }
+
+        const response = await fetch(`${this.endpoint}/api/2.0/mlflow/runs/log-metric`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body)
+        })
+        const json = await response.json()
+        return json
+    }
+
+    async logParam(key, value) {
+        if (!this.activeRunId) {
+            throw new Error('No active run')
+        }
+        const body = {
+            run_id: this.activeRunId,
+            key: key,
+            value: value + '',
+        }
+
+        const response = await fetch(`${this.endpoint}/api/2.0/mlflow/runs/log-parameter`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body)
+        })
+        const json = await response.json()
+        return json
+    }
+}
+
+module.exports = MLflow

--- a/projects/textstream/src/train-browser.js
+++ b/projects/textstream/src/train-browser.js
@@ -1,0 +1,136 @@
+// const tf = require('@tensorflow/tfjs')
+const { encode, decode } = require('gpt-tokenizer/encoding/r50k_base')
+
+const MLflow = require('./mlflow')
+const client = new MLflow({endpoint: 'http://localhost:5000'})
+
+const { createDatasetFromTextStreams, createDatasetFromFileList, vocabSize } = require('./create-dataset')
+const { model, train, optimizers, utils } = require('../../../')
+
+async function sleep (t) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, t);
+  });
+}
+
+function countParams(model) {
+  return model.getWeights()
+    .filter(weight => weight.trainable)
+    .filter(weight => weight.name !== 'lm_head/kernel')
+    .reduce((total, weight) => total + weight.size, 0);
+}
+
+async function handle() {
+    // const files = Array.from(this.files)
+    // const streams = files.map(file => new ReadStream(file, { chunkSize: 4096 }))
+
+    const modelType = 'gpt-nano'
+    const blockSize = 64
+    const batchSize = 4
+
+    await client.createRun(0, `${modelType}-${tf.getBackend()}-${Date.now()}`)
+    await client.logParam('modelType', modelType)
+    await client.logParam('blockSize', blockSize)
+    await client.logParam('batchSize', batchSize)
+    
+    const config = {
+      // nLayer: 3,
+      // nHead: 3,
+      // nEmbd: 48,
+      vocabSize: vocabSize,
+      blockSize: blockSize,
+      modelType: 'gpt-nano',
+      dropout: 0.1,
+      debug: false,
+    }
+
+    const info = document.getElementById('info')
+    for (let i = 0; i < this.files.length; i++) {
+      const file = this.files[i]
+      info.innerHTML += '<br>File: ' + file.name + ' ' + file.size + ' bytes'
+    }
+
+    const gpt = model.GPTLMHeadModel(config)
+    window.gpt = gpt
+    console.log('Model config:', config)
+    console.log('Model params:', countParams(gpt.model))
+    
+    info.innerHTML += '<br>Model config: ' + JSON.stringify(config)
+    info.innerHTML += '<br>Model params: ' + countParams(gpt.model)
+
+    const train_dataset = createDatasetFromFileList(this.files, config.blockSize)
+    
+    // const start = performance.now()
+    let calls = 0
+    let chart = null
+    let g = null
+    let timeNow = Date.now()
+    const losses = []
+    const ctx = document.getElementById('plot')
+    const callback = async (m, loss, iteration) => {
+      // Log each 10th iteration
+      // if (iteration % 10 !== 0) {
+      //   return
+      // }
+
+      // Calculate time diff
+      const time = Date.now()
+      const timeDiff = time - timeNow
+      timeNow = time
+      await client.logMetric('time', timeDiff, iteration)
+
+      // Log loss
+      await client.logMetric('loss', loss, iteration)
+
+      // Generate text
+      const tokens = encode('Roses are red, violets are blue, ')
+      const outputs = await model.generate(
+          m,
+          tokens, 
+          { 'maxLength': 100, 'temperature': 0.7, 'doSample': false },
+      )
+
+      losses.push(loss)
+      if (chart) {
+        chart.data.datasets[0].data = losses
+        chart.data.labels = losses.map((_, i) => i)
+        chart.update()
+      } else {
+        chart = new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: losses.map((_, i) => i),
+            datasets: [{
+              label: 'Loss',
+              data: losses,
+              backgroundColor: 'rgba(255, 99, 132, 0.2)',
+              borderColor: 'rgb(255, 99, 132)',
+              borderWidth: 1
+            }]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+          }
+        })
+      }
+
+      const output = document.getElementById('output')
+      output.innerHTML = '<br>' + decode(outputs[0])
+      calls++
+    } 
+
+    await gpt.train(train_dataset, {
+      epochs: 10,
+      maxIter: 100, 
+      batchSize: batchSize, 
+      verbose: true, 
+      callbacks: [callback]
+    })
+}
+
+const inputElement = document.getElementById("input")
+inputElement.addEventListener("change", handle, false)
+

--- a/projects/textstream/src/train-node.js
+++ b/projects/textstream/src/train-node.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+const tf = require('@tensorflow/tfjs-node');
+
+const { encode, decode } = require('gpt-tokenizer/encoding/r50k_base')
+
+const MLflow = require('./mlflow')
+const client = new MLflow({endpoint: 'http://localhost:5000'})
+
+const { createDatasetFromTextStreams, createDatasetFromFileList, vocabSize } = require('./create-dataset')
+const { model, train, optimizers, utils } = require('../../../')
+
+function createDatasetFromPaths (paths, blockSize) {
+    paths = Array.isArray(paths) ? paths : [paths]
+    function getStreams () {
+        return paths.map(path => fs.createReadStream(path, { encoding: 'utf8', highWaterMark: 128 }))
+    }
+    return createDatasetFromTextStreams(getStreams, blockSize)
+}
+
+async function trainStream () {
+    const modelType = 'gpt-nano'
+    const blockSize = 64
+    const batchSize = 4
+
+    await client.createRun(0, `${modelType}-${tf.getBackend()}-${Date.now()}`)
+    await client.logParam('modelType', modelType)
+    await client.logParam('blockSize', blockSize)
+    await client.logParam('batchSize', batchSize)
+    
+    const config = {
+      // nLayer: 3,
+      // nHead: 3,
+      // nEmbd: 48,
+      vocabSize: vocabSize,
+      blockSize: blockSize,
+      modelType: 'gpt-nano',
+      dropout: 0.1,
+      debug: false,
+    }
+    const gpt = model.GPTLMHeadModel(config)
+
+    const filePath = path.join(__dirname, '../wikitext-103-raw/wiki.train.raw');
+    const train_dataset = createDatasetFromPaths(filePath, 10).batch(1)
+
+    const callback = async (m, loss, iteration) => {
+      // Calculate time diff
+      const time = Date.now()
+      const timeDiff = time - timeNow
+      timeNow = time
+      await client.logMetric('time', timeDiff, iteration)
+
+      // Log loss
+      await client.logMetric('loss', loss, iteration)
+
+      // Generate text
+      const tokens = encode('Roses are red, violets are blue, ')
+      const outputs = await model.generate(
+          m,
+          tokens, 
+          { 'maxLength': 100, 'temperature': 0.7, 'doSample': false },
+      )
+      console.log('Output:', decode(outputs))
+    }
+
+    await gpt.train(train_dataset, {
+      epochs: 10,
+      maxIter: 100, 
+      batchSize: batchSize, 
+      verbose: true, 
+      callbacks: [callback]
+    })
+}
+
+trainStream().catch(console.error)

--- a/projects/textstream/src/train-node.js
+++ b/projects/textstream/src/train-node.js
@@ -13,7 +13,7 @@ const { model, train, optimizers, utils } = require('../../../')
 function createDatasetFromPaths (paths, blockSize) {
     paths = Array.isArray(paths) ? paths : [paths]
     function getStreams () {
-        return paths.map(path => fs.createReadStream(path, { encoding: 'utf8', highWaterMark: 128 }))
+        return paths.map(path => fs.createReadStream(path, { encoding: 'utf8', highWaterMark: 256 }))
     }
     return createDatasetFromTextStreams(getStreams, blockSize)
 }
@@ -40,8 +40,9 @@ async function trainStream () {
     }
     const gpt = model.GPTLMHeadModel(config)
 
-    const filePath = path.join(__dirname, '../wikitext-103-raw/wiki.train.raw');
-    const train_dataset = createDatasetFromPaths(filePath, 10).batch(1)
+    const filePath = path.join(__dirname, '../data/wiki.train.raw');
+    const train_dataset = createDatasetFromPaths(filePath, blockSize)
+    let timeNow = Date.now()
 
     const callback = async (m, loss, iteration) => {
       // Calculate time diff

--- a/projects/textstream/webpack.config.js
+++ b/projects/textstream/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path')
+const webpack = require('webpack')
+const package = require('./package.json')
+
+module.exports = (env) => {
+  const config = {
+    entry: './src/train-browser.js',
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve(__dirname, 'dist'),
+    },
+    plugins: [
+      new webpack.ProvidePlugin({
+        Buffer: ['buffer', 'Buffer'],
+      }),
+      new webpack.ProvidePlugin({
+        process: 'process/browser',
+      }),
+    ],
+    // Ignore tfjs
+    externals: {
+      '@tensorflow/tfjs': 'tf',
+    },
+    // Load different versions of vue based on RUNTIME value
+    resolve: {
+      fallback: {
+        'buffer': require.resolve('buffer'),
+        'path': require.resolve('path-browserify'),
+        'stream': require.resolve('stream-browserify'), // Needed for csv-parse
+      }
+    }
+  }
+
+  return config
+}

--- a/src/model.js
+++ b/src/model.js
@@ -524,12 +524,18 @@ function generateSync(model, idx, conf, callback) {
     idx = prepareIdx(idx)
     for (let step = 0; step < config.maxNewTokens; step++) {
         const { idxNext, timePerToken } = generateOnce(model, idx, config)
-        idx = idx.concat(idxNext, 1);
+        const idxNew = idx.concat(idxNext, 1)
+        tf.dispose(idx)
+        idx = idxNew
+        const idxNextArr = idxNext.arraySync()
+        tf.dispose(idxNext)
         if (callback) {
-            callback({ idxNext: idxNext, timePerToken: timePerToken });
+            callback({ idxNext: idxNextArr, timePerToken: timePerToken });
         }
     }
-    return idx
+    const idxArr = idx.arraySync()
+    tf.dispose(idx)
+    return idxArr
 }
 
 async function generate(model, idx, conf, callback) {
@@ -537,12 +543,18 @@ async function generate(model, idx, conf, callback) {
     idx = await prepareIdx(idx)
     for (let step = 0; step < config.maxNewTokens; step++) {
         const { idxNext, timePerToken } = generateOnce(model, idx, config)
-        idx = idx.concat(idxNext, 1);
+        const idxNew = idx.concat(idxNext, 1)
+        tf.dispose(idx)
+        idx = idxNew
+        const idxNextArr = await idxNext.array()
+        tf.dispose(idxNext)
         if (callback) {
-            await callback({ idxNext: idxNext, timePerToken: timePerToken })
+            await callback({ idxNext: idxNextArr, timePerToken: timePerToken })
         }
     }
-    return idx
+    const idxArr = await idx.array()
+    tf.dispose(idx)
+    return idxArr
 }
 
 const GPTModel = config => new GPTModel_(config)

--- a/src/train.js
+++ b/src/train.js
@@ -42,7 +42,7 @@ async function train (model, ds, config) {
         })
         var opt = new AdamW(config.lr, config.weightDecay, includeInWeightDecay, excludeFromWeightDecay)
     } else {
-        var opt = tf.train.adam(6e-4)
+        var opt = tf.train.adam(config.lr)
     }
 
     let epoch = 1

--- a/src/train.js
+++ b/src/train.js
@@ -3,7 +3,8 @@ const { AdamW, clipByGlobalNorm, clipByGlobalNormObj, l2Loss } = require('./opti
 
 async function train (model, ds, config) {
     const defaultConfig = {
-        epochs: 5,
+        epochs: null,
+        maxIter: null,
         batchSize: 16,
         shuffle: true,
         lr: 6e-4,
@@ -43,31 +44,62 @@ async function train (model, ds, config) {
     } else {
         var opt = tf.train.adam(6e-4)
     }
-    
-    for (let epoch = 1; epoch <= config.epochs; epoch++) {
-        if (config.verbose) { console.log('\nEpoch', epoch) }
-        
-        var losses = []
-        await ds.forEachAsync(({x, y}) => {
-            var optFunc = () => {
-                const logits = model.apply(x)
-                const loss = tf.losses.softmaxCrossEntropy(y, logits)
-                const lossValue = loss.arraySync()
-                losses.push(lossValue)
-                return loss
+
+    let epoch = 1
+    let iteration = 1
+    let iterator = await ds.iterator()
+
+    while (true) {
+        let next = await iterator.next()
+        if (next.done) {
+            epoch++
+            if (config.epochs && epoch > config.epochs) {
+                break
             }
-            tf.tidy(() => {
-                var {values, grads} = opt.computeGradients(optFunc)
-                var gradsClipped = clipByGlobalNormObj(grads, 1)
-                opt.applyGradients(gradsClipped)
-            })
+            iterator = await ds.iterator()
+            next = await iterator.next()
+        }
+        const {x, y} = next.value
+
+        // Keep loss for reporting
+        let loss
+        const optFunc = () => {
+            const logits = model.apply(x)
+            loss = tf.keep(tf.losses.softmaxCrossEntropy(y, logits))
+            return loss
+        }
+        tf.tidy(() => {
+            let {values, grads} = opt.computeGradients(optFunc)
+            let gradsClipped = clipByGlobalNormObj(grads, 1)
+            opt.applyGradients(gradsClipped)
         })
 
-        if (config.verbose) {
-            console.log('Mem:', tf.memory().numTensors)
-            console.log('Loss:', tf.tidy(() => tf.mean(losses).arraySync()))
+        let lossVal = await loss.array()
+        if (Array.isArray(config.callbacks)) {
+            for (let callback of config.callbacks) {
+                await callback(model, lossVal, iteration)
+            }
         }
+
+        // Dispose everything
+        loss.dispose()
+        x.dispose()
+        y.dispose()
+
+        // Check if we should stop
+        iteration++
+        if (config.maxIter && iteration > config.maxIter) {
+            break
+        }
+
+        if (config.verbose) {
+            console.log('Mem:', tf.memory())
+            console.log(`Epoch: ${epoch}, Step: ${iteration}, Loss: ${lossVal}`)
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 1))
     }
+
 }
 
 module.exports = {

--- a/test.js
+++ b/test.js
@@ -160,7 +160,7 @@ test('Load MinGPT model (sorting)', async () => {
 
     // Async generation
     let outputs = await generate(model, tests.model_sort.inputs, { maxNewTokens: 6 })
-    outputs = await outputs.array()
+    // outputs = await outputs.array()
     outputs = outputs[0].slice(6)
     outputs.forEach((o, i) => {
         expect(o).toBe(tests.model_sort.outputs[0][i])
@@ -168,14 +168,14 @@ test('Load MinGPT model (sorting)', async () => {
 
     // Sync generation
     outputs = generateSync(model, tests.model_sort.inputs, { maxNewTokens: 6 })
-    outputs = outputs.arraySync()[0].slice(6)
+    outputs = outputs[0].slice(6)
     outputs.forEach((o, i) => {
         expect(o).toBe(tests.model_sort.outputs[0][i])
     })
 
     // Sync generation (sampling)
     outputsSample = generateSync(model, tests.model_sort.inputs, { maxNewTokens: 6, temperature: 0.1, doSample: true })
-    outputsSample = outputsSample.arraySync()[0].slice(6)
+    outputsSample = outputsSample[0].slice(6)
     let nErrors = 0
     outputsSample.forEach((o, i) => {
         if (o != tests.model_sort.outputs[0][i]) {
@@ -215,13 +215,13 @@ test('Train', async () => {
     const train_dataset = createDataset('train')
     const gpt = GPTLMHeadModel(config)
     const nTensors = tf.memory().numTensors
-    await gpt.train(train_dataset, {epochs: 10, verbose: false}) // Expect this API to change
+    await gpt.train(train_dataset, {epochs: 10, verbose: true}) // Expect this API to change
     const inputs = [2, 2, 2, 1, 0, 1]
     const inputsSorted = inputs.sort()
     const idx = await gpt.generate([inputs], { maxNewTokens: 6 })
-    const outputs = (await idx.array())[0].slice(6)
+    const outputs = idx[0].slice(6)
     outputs.forEach((o, i) => {
         expect(o).toBe(inputsSorted[i])
     })
     return gpt
-})
+}, 30000)


### PR DESCRIPTION
### Added

- `textstream` project: Train GPT model using text stream in browser in node (without loading the whole dataset into memory)
- Support both `maxIter` and `epochs` in the `train` method. Switched from `df.forEachAsync` to `while` loop + `ds.iterator()` (it was not clear how to terminate long-running `forEachAsync`).

### Fixed

- Memory leakage in the `generate` method
- Use `config.lr` in the Adam optimizer